### PR TITLE
Add Shadow Play plugin for replay-based gameplay

### DIFF
--- a/osu.Plugin.Trainer/ShadowPlay/ShadowPlayButton.cs
+++ b/osu.Plugin.Trainer/ShadowPlay/ShadowPlayButton.cs
@@ -1,0 +1,198 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Game;
+using osu.Game.Beatmaps;
+using osu.Game.Graphics;
+using osu.Game.Graphics.UserInterface;
+using osu.Game.Online;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Scoring;
+using osu.Game.Screens;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.Leaderboards;
+using osu.Game.Screens.Ranking;
+using osu.Game.Utils;
+using osuTK;
+
+namespace osu.Plugin.Trainer.ShadowPlay;
+
+internal partial class ShadowPlayButton : OsuAnimatedButton
+{
+    public readonly Bindable<ScoreInfo?> SelectedScore = new Bindable<ScoreInfo?>();
+    public readonly Bindable<DownloadState> ReplayDownloadState = new Bindable<DownloadState>();
+
+    private Box background = null!;
+
+    [Resolved]
+    private OsuColour colours { get; set; } = null!;
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        Size = new Vector2(50, 30);
+
+        Children = new Drawable[]
+        {
+            background = new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+            },
+            new SpriteIcon
+            {
+                Anchor = Anchor.Centre,
+                Origin = Anchor.Centre,
+                Size = new Vector2(13),
+                Icon = FontAwesome.Solid.Video,
+            }
+        };
+
+        // should we schedule it?
+        SelectedScore.BindValueChanged(_ => updateEnabledState());
+        ReplayDownloadState.BindValueChanged(_ => updateEnabledState(), true);
+    }
+
+    private void updateEnabledState()
+    {
+        var enabled = SelectedScore.Value is { } score
+            && ReplayDownloadState.Value is DownloadState.LocallyAvailable
+            // obviously, only osu!std is is support since we are using mouse
+            && score.RulesetID is 0;
+
+        Enabled.Value = enabled;
+
+        background.Colour = enabled ? colours.Green : colours.Gray8;
+    }
+
+    [Resolved]
+    private ScoreManager scoreManager { get; set; } = null!;
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        Action = () =>
+        {
+            var selectedScore = SelectedScore.Value;
+
+            if (selectedScore is null)
+                return;
+
+            Score? databasedScore;
+
+            try
+            {
+                databasedScore = scoreManager.GetScore(selectedScore);
+
+                if (databasedScore is null)
+                    throw new InvalidOperationException("Selected score is not available in the database.");
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to retrieve score from database.");
+                return;
+            }
+
+            try
+            {
+                attachModAndStartGameplay(databasedScore);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex, "Failed to start Shadow Play gameplay.");
+            }
+        };
+    }
+
+    [Resolved]
+    private OsuGame game { get; set; } = null!;
+
+    [Resolved]
+    private Bindable<RulesetInfo> ruleset { get; set; } = null!;
+
+    [Resolved]
+    private Bindable<WorkingBeatmap> beatmap { get; set; } = null!;
+
+    [Resolved]
+    private BeatmapManager beatmapManager { get; set; } = null!;
+
+    [Resolved]
+    private Bindable<IReadOnlyList<Mod>> selectedMods { get; set; } = null!;
+
+    private void attachModAndStartGameplay(Score replayScore)
+    {
+        var spMod = new ShadowPlayMod(replayScore);
+        var targetMods = replayScore.ScoreInfo.Mods
+                                        .Select(m => m.DeepClone())
+                                        .Append(spMod)
+                                        .ToList();
+
+        // we may want user selected mods to be applied as well, such as NoFail
+        targetMods = selectedMods.Value.Concat(targetMods)
+                                       .DistinctBy(m => m.Acronym) // in case of duplicate mods, keep the ones from selectedMods since they are more likely to be intentional by the user.
+                                       .ToList();
+
+        if (!ModUtils.CheckValidForGameplay(targetMods, out var invalidMods))
+            invalidMods.ForEach(m => targetMods.Remove(m));
+
+        var beatmap = replayScore.ScoreInfo.BeatmapInfo;
+
+        game.PerformFromScreen(screen =>
+        {
+            Debug.Assert(screen.ValidForPush, $"Current screen {screen} is not valid for push, cannot start gameplay.");
+
+            Logger.Log($"{nameof(attachModAndStartGameplay)} updating beatmap ({beatmap}) and ruleset ({replayScore.ScoreInfo.Ruleset}) to match score");
+
+            if (!ruleset.Value.Equals(replayScore.ScoreInfo.Ruleset))
+                ruleset.Value = replayScore.ScoreInfo.Ruleset;
+
+            if (!this.beatmap.Value.BeatmapInfo.Equals(beatmap))
+                this.beatmap.Value = beatmapManager.GetWorkingBeatmap(beatmap);
+
+            var mods = targetMods.ToImmutableArray();
+
+            ((OsuScreen)screen).Mods.Value = mods;
+            selectedMods.Value = mods;
+
+            screen.Push(new PlayerLoader(createPlayer));
+
+            // FIXME: keeping song select screen loses SP mod?
+        });
+
+        Player createPlayer() => new OfflinePlayer(playerConfiguration);
+    }
+
+    private static readonly PlayerConfiguration playerConfiguration = new PlayerConfiguration
+    {
+        ShowLeaderboard = true,
+        ShowResults = true,
+    };
+
+    // A player that doesn't submit scores.
+    // this is used since our mod is locally implemented and we don't want to mess with the player's actual score.
+    private partial class OfflinePlayer : Player
+    {
+        [Cached(typeof(IGameplayLeaderboardProvider))]
+        [SuppressMessage("CodeQuality", "IDE0052", Justification = "DI usage")]
+        private readonly SoloGameplayLeaderboardProvider leaderboardProvider = new SoloGameplayLeaderboardProvider();
+
+        public OfflinePlayer(PlayerConfiguration configuration = null!)
+            : base(configuration)
+        {
+        }
+
+        protected override ResultsScreen CreateResults(ScoreInfo score) => new SoloResultsScreen(score)
+        {
+            AllowRetry = true,
+            IsLocalPlay = true,
+        };
+    }
+}

--- a/osu.Plugin.Trainer/ShadowPlay/ShadowPlayMod.cs
+++ b/osu.Plugin.Trainer/ShadowPlay/ShadowPlayMod.cs
@@ -1,0 +1,103 @@
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Input.StateChanges;
+using osu.Framework.Localisation;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Rulesets.Osu.Mods;
+using osu.Game.Rulesets.Osu.Objects;
+using osu.Game.Rulesets.Osu.Replays;
+using osu.Game.Rulesets.Osu.UI;
+using osu.Game.Rulesets.UI;
+using osu.Game.Scoring;
+
+namespace osu.Plugin.Trainer.ShadowPlay;
+
+internal partial class ShadowPlayMod : Mod, IUpdatableByPlayfield, IApplicableToDrawableRuleset<OsuHitObject>
+{
+    private readonly Score score = null!;
+
+    public override bool Ranked => false;
+
+    public override string Name => "Shadow Play";
+
+    public override string Acronym => "SP";
+
+    public override LocalisableString Description => "Play with the movement of the replay. For training purposes.";
+
+    // i would like it to be as same as 0.1 of OsuModAutopilot
+    // but as a trainer mod that doesn't affect score, let's just make it 1x for now
+    public override double ScoreMultiplier => 1;
+
+    public override Type[] IncompatibleMods => new[]
+    {
+            typeof(OsuModSpunOut),
+            typeof(ModRelax),
+            typeof(ModAutoplay),
+            typeof(OsuModMagnetised),
+            typeof(OsuModRepel),
+            // typeof(ModTouchDevice),
+        };
+
+    public override ModType Type => ModType.Automation;
+
+    public override bool AlwaysValidForSubmission => false;
+
+    public override IconUsage? Icon => FontAwesome.Solid.Video;
+
+    public ShadowPlayMod() { }
+
+    public ShadowPlayMod(Score score)
+    {
+        this.score = score;
+    }
+
+    public override Mod DeepClone()
+    {
+        return new ShadowPlayMod(score);
+    }
+
+    private OsuInputManager inputManager = null!;
+
+    private List<OsuReplayFrame> replayFrames = null!;
+
+    private int currentFrame = -1;
+
+    public void Update(Playfield playfield)
+    {
+        // copied from OsuModAutopilot
+
+        if (currentFrame >= replayFrames.Count - 1) return;
+
+        double time = playfield.Clock.CurrentTime;
+
+        // Very naive implementation of autopilot based on proximity to replay frames.
+        // Special case for the first frame is required to ensure the mouse is in a sane position until the actual time of the first frame is hit.
+        // TODO: this needs to be based on user interactions to better match stable (pausing until judgement is registered).
+        if (currentFrame < 0 || Math.Abs(replayFrames[currentFrame + 1].Time - time) <= Math.Abs(replayFrames[currentFrame].Time - time))
+        {
+            currentFrame++;
+            new MousePositionAbsoluteInput { Position = playfield.ToScreenSpace(replayFrames[currentFrame].Position) }.Apply(inputManager.CurrentState, inputManager);
+        }
+
+        // TODO: Implement the functionality to automatically spin spinners
+    }
+
+    public void ApplyToDrawableRuleset(DrawableRuleset<OsuHitObject> drawableRuleset)
+    {
+        // Grab the input manager to disable the user's cursor, and for future use
+        inputManager = ((DrawableOsuRuleset)drawableRuleset).KeyBindingInputManager;
+        inputManager.AllowUserCursorMovement = false;
+
+        // when replay a score with SP mod, 
+        // the replay frames are not loaded for some reason.
+        // this is expected, as the replay frames are stored in the database.
+        // But it's not necessary to load the replay frames from the database, since the playing replay already recorded those frames
+        // so we just create a empty replay frames list and pretend this mod doesn't exist.
+        // Debug.Assert(score != null, "Score should not be null when applying ShadowPlayMod.");
+
+        replayFrames = score?.Replay
+                            .Frames
+                            .Cast<OsuReplayFrame>()
+                            .ToList() ?? new();
+    }
+}

--- a/osu.Plugin.Trainer/ShadowPlay/ShadowPlayPlugin.cs
+++ b/osu.Plugin.Trainer/ShadowPlay/ShadowPlayPlugin.cs
@@ -1,0 +1,103 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+using osu.Framework.Bindables;
+using osu.Framework.Screens;
+using osu.Framework.Testing;
+using osu.Framework.Threading;
+using osu.Game;
+using osu.Game.Online;
+using osu.Game.Plugins;
+using osu.Game.Rulesets;
+using osu.Game.Rulesets.Mods;
+using osu.Game.Rulesets.Osu;
+using osu.Game.Scoring;
+using osu.Game.Screens.Ranking;
+
+namespace osu.Plugin.Trainer.ShadowPlay;
+
+/// <summary>
+/// A plugin that implements a similar feature to the mod Autopilot, 
+/// but instead of controlling the cursor with an algorithm, 
+/// it allows you play with the movement of a replay.
+/// </summary>
+public partial class ShadowPlayPlugin : OsuPlugin
+{
+    private void registerShadowPlayMod()
+    {
+        var osuRuleset = new OsuRuleset();
+
+        var mods = typeof(Ruleset).GetField("mod_reference_cache", BindingFlags.NonPublic | BindingFlags.Static)?
+            .GetValue(null) as ConcurrentDictionary<string, IMod[]>;
+
+        if (mods is not null)
+        {
+            var osuMods = osuRuleset.AllMods.Where(m => m is not ShadowPlayMod)
+                                            .Append(new ShadowPlayMod())
+                                            .ToArray();
+
+            mods[osuRuleset.ShortName] = osuMods;
+        }
+    }
+
+    public override void OnLoad(OsuGameBase gameBase, Scheduler scheduler)
+    {
+        if (gameBase is not OsuGame game)
+            return;
+
+        var selectedScore = new Bindable<ScoreInfo?>();
+
+        game.InvokeWhenReady(d =>
+        {
+            registerShadowPlayMod();
+
+            var screenStack = game.ScreenStack;
+
+            screenStack.ScreenPushed += onScreenSwitched;
+            screenStack.ScreenExited += onScreenSwitched;
+        });
+
+        void onScreenSwitched(IScreen oldScreen, IScreen newScreen)
+        {
+            if (oldScreen is SoloResultsScreen)
+                selectedScore.UnbindAll();
+
+            // donno if we should use ResultsScreen or SoloResultsScreen,
+            // but let's just use SoloResultsScreen for now since it's more specific.
+            if (newScreen is not SoloResultsScreen soloResultsScreen)
+                return;
+
+            selectedScore.BindTo(soloResultsScreen.SelectedScore);
+
+            soloResultsScreen.InvokeWhenReady(d =>
+            {
+                var resultsScreen = (ResultsScreen)d;
+
+                // we should at least be able to watch the replay to use this plugin, so if it's not allowed, we won't show the button at all.
+                if (!resultsScreen.AllowWatchingReplay)
+                    return;
+
+                var watchReplayButton = resultsScreen.ChildrenOfType<ReplayDownloadButton>().FirstOrDefault();
+
+                // somehow this may be null, but if it is, we won't show the button at all.
+                if (watchReplayButton is null)
+                    return;
+
+                // i guess non-specificly targeting the container is fine since we only care about adding a button.
+                var buttonsContainer = watchReplayButton.Parent;
+
+                if (buttonsContainer is null)
+                    return;
+
+                buttonsContainer.AddInternal(new ShadowPlayButton()
+                {
+                    SelectedScore = { BindTarget = selectedScore },
+                    ReplayDownloadState = { BindTarget = (Bindable<DownloadState>)replayDownloadStateField?.GetValue(watchReplayButton) },
+                });
+            });
+        }
+    }
+
+    // we may want static binding for compilation-time safety
+    private static FieldInfo? replayDownloadStateField = typeof(ReplayDownloadButton)
+        .GetField("State", BindingFlags.NonPublic | BindingFlags.Instance);
+}

--- a/osu.Plugin.Trainer/ShadowPlay/ShadowPlayPlugin.cs
+++ b/osu.Plugin.Trainer/ShadowPlay/ShadowPlayPlugin.cs
@@ -88,11 +88,23 @@ public partial class ShadowPlayPlugin : OsuPlugin
                 if (buttonsContainer is null)
                     return;
 
-                buttonsContainer.AddInternal(new ShadowPlayButton()
+                var shadowPlayButton = new ShadowPlayButton()
                 {
                     SelectedScore = { BindTarget = selectedScore },
-                    ReplayDownloadState = { BindTarget = (Bindable<DownloadState>)replayDownloadStateField?.GetValue(watchReplayButton) },
-                });
+                };
+
+                if (replayDownloadStateField != null)
+                {
+                    var replayStateObj = replayDownloadStateField.GetValue(watchReplayButton);
+                    var replayDownloadState = replayStateObj as Bindable<DownloadState>;
+
+                    if (replayDownloadState != null)
+                    {
+                        shadowPlayButton.ReplayDownloadState.BindTarget = replayDownloadState;
+                    }
+                }
+
+                buttonsContainer.AddInternal(shadowPlayButton);
             });
         }
     }


### PR DESCRIPTION
Introduce a new plugin that allows users to play using the movement of a replay, enhancing training capabilities. This includes the implementation of the Shadow Play mod, which integrates with the existing gameplay mechanics.