### PR TITLE
Update ppy.osu.Game package version to 2026.408.0

### DIFF
--- a/osu.Game.Plugins.Skins/osu.Game.Plugins.Skins.csproj
+++ b/osu.Game.Plugins.Skins/osu.Game.Plugins.Skins.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Game.Plugins/osu.Game.Plugins.csproj
+++ b/osu.Game.Plugins/osu.Game.Plugins.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Game.Rulesets.PluginsLoader.Tests/osu.Game.Rulesets.PluginsLoader.Tests.csproj
+++ b/osu.Game.Rulesets.PluginsLoader.Tests/osu.Game.Rulesets.PluginsLoader.Tests.csproj
@@ -20,9 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0" />
     <!-- for test purpose, can be commented if unnecessary -->
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.317.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.408.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References">

--- a/osu.Game.Rulesets.PluginsLoader/osu.Game.Rulesets.PluginsLoader.csproj
+++ b/osu.Game.Rulesets.PluginsLoader/osu.Game.Rulesets.PluginsLoader.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Plugin.LegacyExperience.Tests/osu.Plugin.LegacyExperience.Tests.csproj
+++ b/osu.Plugin.LegacyExperience.Tests/osu.Plugin.LegacyExperience.Tests.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.317.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.317.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.317.0" />
-    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.317.0" />
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.408.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Taiko" Version="2026.408.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Catch" Version="2026.408.0" />
+    <PackageReference Include="ppy.osu.Game.Rulesets.Mania" Version="2026.408.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References">

--- a/osu.Plugin.LegacyExperience/osu.Plugin.LegacyExperience.csproj
+++ b/osu.Plugin.LegacyExperience/osu.Plugin.LegacyExperience.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Plugin.MainMenuPlayer/osu.Plugin.MainMenuPlayer.csproj
+++ b/osu.Plugin.MainMenuPlayer/osu.Plugin.MainMenuPlayer.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Plugin.StableIntegration/osu.Plugin.StableIntegration.csproj
+++ b/osu.Plugin.StableIntegration/osu.Plugin.StableIntegration.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Plugin.Template/osu.Plugin.Template.csproj
+++ b/osu.Plugin.Template/osu.Plugin.Template.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/osu.Plugin.Trainer/osu.Plugin.Trainer.csproj
+++ b/osu.Plugin.Trainer/osu.Plugin.Trainer.csproj
@@ -17,10 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ppy.osu.Game" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.317.0">
+    <PackageReference Include="ppy.osu.Game.Rulesets.Osu" Version="2026.408.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
see #62 

ai slop:
-----

Update the ppy.osu.Game package version across multiple projects to ensure compatibility with the latest features and fixes. This change addresses version discrepancies and maintains consistency across the codebase.