### PR TITLE
Improve multiplayer chat channel management

### DIFF
--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -56,7 +56,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         continue;
 
                     // osu-spectator-server removes players from the channel via interop with osu-web,
-                    // and this operation may fail and cause the player to remain in the channel without actually being able to receive messages.
+                    // and this operation may fail and cause the player to remain in the channel.
                     // in this case, those *ghost* channels are still joined,
                     // even though we can still receive and send messages to them, 
                     // we should not display them in the channel list as they are not functional and will just cause confusion.

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -68,7 +68,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         c.Type = display_section;
 
                         // give it a more descriptive name in the channel list, as the original name is just the room id which isn't very helpful.
-                        c.Name = $"#Multiplayer ({name.TrimStart('#')})";
+                        c.Name = $"#Multiplayer ({trimChannelName(name)})";
                         channelList?.AddChannel(c);
                     }
                     catch (Exception ex)
@@ -125,6 +125,16 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                 }, c);
             }
         });
+    }
+
+    private string trimChannelName(string name)
+    {
+        const string prefix = "#lazermp_";
+
+        var index = name.IndexOf(prefix, StringComparison.Ordinal) + 1;
+
+        // extract room id from channel name, which is in the format of #lazermp_{roomId}
+        return index > 0 ? name[index..] : name;
     }
 
     // WORKAROUND: 

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -112,6 +112,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                     catch (Exception ex)
                     {
                         Logger.Error(ex, $"Failed to add channel {c.Name} to the channel list.");
+                        removeChannel(c);
                         return;
                     }
                     finally

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -68,7 +68,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         c.Type = display_section;
 
                         // give it a more descriptive name in the channel list, as the original name is just the room id which isn't very helpful.
-                        c.Name = $"#Multiplayer ({trimChannelName(name)})";
+                        c.Name = $"#Multiplayer ({trimChannelName(name)}, {c.Topic})"; // the topic is the room name
                         channelList?.AddChannel(c);
                     }
                     catch (Exception ex)

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -112,6 +112,11 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                     catch (Exception ex)
                     {
                         Logger.Error(ex, $"Failed to add channel {c.Name} to the channel list.");
+
+                        // ChatOverlay relies on ChannelType for sectioning
+                        c.Type = originalType;
+                        c.Name = name;
+
                         removeChannel(c);
                         return;
                     }

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -70,6 +70,10 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         // give it a more descriptive name in the channel list, as the original name is just the room id which isn't very helpful.
                         c.Name = $"#Multiplayer ({trimChannelName(name)}, {c.Topic})"; // the topic is the room name
                         channelList?.AddChannel(c);
+
+                        // set the current channel to the newly joined multiplayer channel for smoother experience, 
+                        // as players are likely to want to see the multiplayer chat immediately after joining a room.
+                        currentChannel.Value = c;
                     }
                     catch (Exception ex)
                     {

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -51,6 +51,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
 
                 foreach (var c in newChannels)
                 {
+                    // ugly as it may be, this is the only way we can reliably detect room status for playlists(as well as DailyChallenge).
                     if (!long.TryParse(trimChannelName(c.Name), out long roomId))
                         continue;
 

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -82,6 +82,11 @@ public partial class MultiplayerChatPlugin : OsuPlugin
 
             void registerNewChannel(Channel c, Room r)
             {
+                // if the user left before request completes,
+                // we should not add the channel to the list as it will just cause confusion and potential issues with the chat overlay.
+                if (!c.Joined.Value)
+                    return;
+
                 if (trackingChannels.ContainsKey(c.Id))
                     return;
 

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -108,14 +108,11 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         // give it a more descriptive name in the channel list, as the original name is just the room id which isn't very helpful.
                         c.Name = $"#Multiplayer ({r.RoomID}, {r.Name})"; // the topic is the room name
                         channelList?.AddChannel(c);
-
-                        // set the current channel to the newly joined multiplayer channel for smoother experience, 
-                        // as players are likely to want to see the multiplayer chat immediately after joining a room.
-                        currentChannel.Value = c;
                     }
                     catch (Exception ex)
                     {
                         Logger.Error(ex, $"Failed to add channel {c.Name} to the channel list.");
+                        return;
                     }
                     finally
                     {
@@ -123,6 +120,10 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         c.Type = originalType;
                         c.Name = name;
                     }
+
+                    // set the current channel to the newly joined multiplayer channel for smoother experience, 
+                    // as players are likely to want to see the multiplayer chat immediately after joining a room.
+                    currentChannel.Value = c;
 
                     joined.BindValueChanged(j =>
                     {

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -5,8 +5,9 @@ using osu.Framework.Bindables;
 using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Game;
+using osu.Game.Online.API;
 using osu.Game.Online.Chat;
-using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Chat.ChannelList;
 using osu.Game.Plugins;
@@ -28,30 +29,15 @@ public partial class MultiplayerChatPlugin : OsuPlugin
         {
             var game = (OsuGame)d;
 
-            var multiplayerClient = game.Dependencies.Get<MultiplayerClient>();
+            var api = game.Dependencies.Get<IAPIProvider>();
 
             var channelManager = game.Dependencies.Get<ChannelManager>();
             var chatOverlay = game.Dependencies.Get<ChatOverlay>();
 
             var trackingChannels = new Dictionary<long, Bindable<bool>>();
-            var pendingList = new HashSet<Channel>();
 
             var currentChannel = channelManager.CurrentChannel;
             var joinedChannels = channelManager.JoinedChannels;
-
-            multiplayerClient.RoomUpdated += () =>
-            {
-                var room = multiplayerClient.Room;
-
-                if (room is null)
-                {
-                    pendingList.Clear();
-                }
-                else if (pendingList.FirstOrDefault(c => c.Id == room?.ChannelID) is { } channel)
-                {
-                    registerNewChannel(channel);
-                }
-            };
 
             joinedChannels.BindCollectionChanged((_, arg) =>
             {
@@ -65,25 +51,36 @@ public partial class MultiplayerChatPlugin : OsuPlugin
 
                 foreach (var c in newChannels)
                 {
-                    pendingList.Add(c);
-                    registerNewChannel(c);
+                    if (!long.TryParse(trimChannelName(c.Name), out long roomId))
+                        continue;
+
+                    // osu-spectator-server removes players from the channel via interop with osu-web,
+                    // and this operation may fail and cause the player to remain in the channel without actually being able to receive messages.
+                    // in this case, those *ghost* channels are still joined,
+                    // even though we can still receive and send messages to them, 
+                    // we should not display them in the channel list as they are not functional and will just cause confusion.
+
+                    var req = new GetRoomRequest(roomId);
+
+                    req.Failure += e =>
+                    {
+                        Logger.Error(e, $"Failed to get room info for channel {c.Name}, skipping channel registration.");
+                    };
+
+                    req.Success += r =>
+                    {
+                        if (!r.HasEnded)
+                            scheduler.AddOnce(c => registerNewChannel(c, r), c);
+                        else
+                            Logger.Log($"Room {r.RoomID} has already ended, skipping channel registration.", LoggingTarget.Runtime, LogLevel.Verbose);
+                    };
+
+                    api.Queue(req);
                 }
             }, true);
 
-            void registerNewChannel(Channel c)
+            void registerNewChannel(Channel c, Room r)
             {
-                // FIXME:
-                // osu-spectator-server removes players from the channel via interop with osu-web,
-                // and this operation may fail and cause the player to remain in the channel without actually being able to receive messages.
-                // in this case, those *ghost* channels are still joined,
-                // even though we can still receive and send messages to them, 
-                // we should not display them in the channel list as they are not functional and will just cause confusion.
-
-                if (multiplayerClient.Room?.ChannelID != c.Id)
-                    return;
-
-                pendingList.RemoveWhere(t => t.Id == c.Id);
-
                 if (trackingChannels.ContainsKey(c.Id))
                     return;
 
@@ -93,6 +90,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                 scheduler.AddOnce(c =>
                 {
                     string name = c.Name;
+                    var originalType = c.Type;
 
                     try
                     {
@@ -102,7 +100,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                         c.Type = display_section;
 
                         // give it a more descriptive name in the channel list, as the original name is just the room id which isn't very helpful.
-                        c.Name = $"#Multiplayer ({trimChannelName(name)}, {c.Topic})"; // the topic is the room name
+                        c.Name = $"#Multiplayer ({r.RoomID}, {r.Name})"; // the topic is the room name
                         channelList?.AddChannel(c);
 
                         // set the current channel to the newly joined multiplayer channel for smoother experience, 
@@ -116,7 +114,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                     finally
                     {
                         // set it back to multiplayer so that roll command works.
-                        c.Type = ChannelType.Multiplayer;
+                        c.Type = originalType;
                         c.Name = name;
                     }
 
@@ -132,8 +130,6 @@ public partial class MultiplayerChatPlugin : OsuPlugin
 
             void removeChannel(Channel c)
             {
-                pendingList.RemoveWhere(t => t.Id == c.Id);
-
                 if (trackingChannels.Remove(c.Id, out var joined))
                     joined.UnbindAll();
 

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -135,10 +135,13 @@ public partial class MultiplayerChatPlugin : OsuPlugin
     {
         const string prefix = "#lazermp_";
 
-        var index = name.IndexOf(prefix, StringComparison.Ordinal) + 1;
+        var index = name.IndexOf(prefix, StringComparison.Ordinal);
+
+        if (index < 0)
+            return name;
 
         // extract room id from channel name, which is in the format of #lazermp_{roomId}
-        return index > 0 ? name[index..] : name;
+        return name[(index + prefix.Length)..];
     }
 
     // WORKAROUND: 

--- a/osu.Plugin.Patches/MultiplayerChatPlugin.cs
+++ b/osu.Plugin.Patches/MultiplayerChatPlugin.cs
@@ -6,6 +6,7 @@ using osu.Framework.Logging;
 using osu.Framework.Threading;
 using osu.Game;
 using osu.Game.Online.Chat;
+using osu.Game.Online.Multiplayer;
 using osu.Game.Overlays;
 using osu.Game.Overlays.Chat.ChannelList;
 using osu.Game.Plugins;
@@ -27,12 +28,30 @@ public partial class MultiplayerChatPlugin : OsuPlugin
         {
             var game = (OsuGame)d;
 
+            var multiplayerClient = game.Dependencies.Get<MultiplayerClient>();
+
             var channelManager = game.Dependencies.Get<ChannelManager>();
             var chatOverlay = game.Dependencies.Get<ChatOverlay>();
 
             var trackingChannels = new Dictionary<long, Bindable<bool>>();
+            var pendingList = new HashSet<Channel>();
 
+            var currentChannel = channelManager.CurrentChannel;
             var joinedChannels = channelManager.JoinedChannels;
+
+            multiplayerClient.RoomUpdated += () =>
+            {
+                var room = multiplayerClient.Room;
+
+                if (room is null)
+                {
+                    pendingList.Clear();
+                }
+                else if (pendingList.FirstOrDefault(c => c.Id == room?.ChannelID) is { } channel)
+                {
+                    registerNewChannel(channel);
+                }
+            };
 
             joinedChannels.BindCollectionChanged((_, arg) =>
             {
@@ -45,11 +64,26 @@ public partial class MultiplayerChatPlugin : OsuPlugin
                     removeChannel(c);
 
                 foreach (var c in newChannels)
+                {
+                    pendingList.Add(c);
                     registerNewChannel(c);
+                }
             }, true);
 
             void registerNewChannel(Channel c)
             {
+                // FIXME:
+                // osu-spectator-server removes players from the channel via interop with osu-web,
+                // and this operation may fail and cause the player to remain in the channel without actually being able to receive messages.
+                // in this case, those *ghost* channels are still joined,
+                // even though we can still receive and send messages to them, 
+                // we should not display them in the channel list as they are not functional and will just cause confusion.
+
+                if (multiplayerClient.Room?.ChannelID != c.Id)
+                    return;
+
+                pendingList.RemoveWhere(t => t.Id == c.Id);
+
                 if (trackingChannels.ContainsKey(c.Id))
                     return;
 
@@ -98,8 +132,7 @@ public partial class MultiplayerChatPlugin : OsuPlugin
 
             void removeChannel(Channel c)
             {
-                if (c.Joined.Value)
-                    return;
+                pendingList.RemoveWhere(t => t.Id == c.Id);
 
                 if (trackingChannels.Remove(c.Id, out var joined))
                     joined.UnbindAll();


### PR DESCRIPTION
Enhance channel naming by extracting room IDs and including topics for better clarity. Set the current channel to the newly joined multiplayer channel to improve user experience and manage ghost channels effectively.