### PR TITLE
Add LowLatencyKeyboardPlugin for Windows Raw Keyboard hint in SDL3

### DIFF
--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -1,3 +1,4 @@
+using osu.Framework;
 using osu.Framework.Allocation;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
@@ -26,17 +27,17 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
             return;
         }
 
+        if (!FrameworkEnvironment.UseSDL3)
+        {
+            Logger.Log("Low latency keyboard hint is only supported on SDL3, considering set OSU_SDL3=1 to enable it.", LoggingTarget.Runtime, LogLevel.Important);
+            return;
+        }
+
         game.InvokeWhenReady(d =>
         {
             var game = (OsuGame)d;
 
             var host = game.Dependencies.Get<GameHost>();
-
-            if (!IsSDL3Window(host.Window))
-            {
-                Logger.Log("Low latency keyboard hint is only supported on SDL3, considering set OSU_SDL3=1 to enable it.", LoggingTarget.Runtime, LogLevel.Important);
-                return;
-            }
 
             SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
 
@@ -50,16 +51,6 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
             if (hintValue != "1")
                 Logger.Log($"Failed to set low latency keyboard hint, current value {hintValue}, error: {SDL3.SDL_GetError()}", LoggingTarget.Runtime, LogLevel.Error);
         });
-    }
-
-    private static bool IsSDL3Window(IWindow window)
-    {
-        var windowType = window.GetType();
-
-        if (windowType.IsAssignableTo(SDL3Window_Type))
-            return true;
-
-        return windowType.FullName?.Contains("SDL3") ?? false;
     }
 
     private static readonly Type SDL3Window_Type = typeof(GameHost).Assembly.GetType("osu.Framework.Platform.SDL3.SDL3Window")!;

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -41,9 +41,19 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
 
             SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
 
-            // This makes Win-key blocker work when raw input is enabled.
-            // after all low latency isn't meaningful for hotkeys
-            SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+            int sdlVersion = SDL3.SDL_GetVersion();
+
+            // see https://wiki.libsdl.org/SDL3/SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS
+            if (sdlVersion >= SDL3.SDL_VERSIONNUM(3, 4, 0))
+            {
+                // This makes Win-key blocker work when raw input is enabled.
+                // after all low latency isn't meaningful for hotkeys
+                SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+            }
+            else
+            {
+                Logger.Log("SDL version does not support excluding hotkeys from raw keyboard input, Win-key blocker may not work properly when raw input is enabled.", LoggingTarget.Runtime, LogLevel.Important);
+            }
 
             var hintValue = SDL3.SDL_GetHint(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD);
             Logger.Log($"Low latency keyboard hint value: {hintValue}", LoggingTarget.Runtime, LogLevel.Verbose);

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -1,0 +1,62 @@
+using osu.Framework.Allocation;
+using osu.Framework.Logging;
+using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Game;
+using osu.Game.Plugins;
+using SDL;
+
+namespace osu.Plugin.Patches;
+
+/// <summary>
+/// This plugin enables the Windows Raw Keyboard hint in SDL3, which can reduce input latency for keyboards on Windows.
+/// see https://wiki.libsdl.org/SDL3/SDL_HINT_WINDOWS_RAW_KEYBOARD and https://github.com/ppy/osu-framework/pull/6507.
+/// There's known issue, refer to ppy/osu-framework/pull/6507.
+/// </summary>
+public partial class LowLatencyKeyboardPlugin : OsuPlugin
+{
+    public override void OnLoad(OsuGameBase gameBase, Scheduler scheduler)
+    {
+        if (gameBase is not OsuGame game)
+            return;
+
+        if (!OperatingSystem.IsWindows())
+        {
+            Logger.Log("Low latency keyboard patch is only supported on Windows, skipping.");
+            return;
+        }
+
+        game.InvokeWhenReady(d =>
+        {
+            var game = (OsuGame)d;
+
+            var host = game.Dependencies.Get<GameHost>();
+
+            if (!IsSDL3Window(host.Window))
+            {
+                Logger.Log("Low latency keyboard hint is only supported on SDL3, considering set OSU_SDL3=1 to enable it.", LoggingTarget.Runtime, LogLevel.Important);
+                return;
+            }
+
+            SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+
+            var hintValue = SDL3.SDL_GetHint(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD);
+            Logger.Log($"Low latency keyboard hint value: {hintValue}", LoggingTarget.Runtime, LogLevel.Verbose);
+
+            if (hintValue != "1")
+                Logger.Log($"Failed to set low latency keyboard hint, current value {hintValue}, error: {SDL3.SDL_GetError()}", LoggingTarget.Runtime, LogLevel.Error);
+        });
+    }
+
+    private static bool IsSDL3Window(IWindow window)
+    {
+        var windowType = window.GetType();
+
+        if (windowType.IsAssignableTo(SDL3Window_Type))
+            return true;
+
+        return windowType.FullName?.Contains("SDL3") ?? false;
+    }
+
+    private static readonly Type SDL3Window_Type = typeof(GameHost).Assembly.GetType("osu.Framework.Platform.SDL3.SDL3Window")!;
+}

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -33,33 +33,26 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
             return;
         }
 
-        game.InvokeWhenReady(d =>
+        SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+
+        int sdlVersion = SDL3.SDL_GetVersion();
+
+        // see https://wiki.libsdl.org/SDL3/SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS
+        if (sdlVersion >= SDL3.SDL_VERSIONNUM(3, 4, 0))
         {
-            var game = (OsuGame)d;
+            // This makes Win-key blocker work when raw input is enabled.
+            // after all low latency isn't meaningful for hotkeys
+            SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+        }
+        else
+        {
+            Logger.Log("SDL version does not support excluding hotkeys from raw keyboard input, Win-key blocker may not work properly when raw input is enabled.", LoggingTarget.Runtime, LogLevel.Important);
+        }
 
-            var host = game.Dependencies.Get<GameHost>();
+        var hintValue = SDL3.SDL_GetHint(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD);
+        Logger.Log($"Low latency keyboard hint value: {hintValue}", LoggingTarget.Runtime, LogLevel.Verbose);
 
-            SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
-
-            int sdlVersion = SDL3.SDL_GetVersion();
-
-            // see https://wiki.libsdl.org/SDL3/SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS
-            if (sdlVersion >= SDL3.SDL_VERSIONNUM(3, 4, 0))
-            {
-                // This makes Win-key blocker work when raw input is enabled.
-                // after all low latency isn't meaningful for hotkeys
-                SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
-            }
-            else
-            {
-                Logger.Log("SDL version does not support excluding hotkeys from raw keyboard input, Win-key blocker may not work properly when raw input is enabled.", LoggingTarget.Runtime, LogLevel.Important);
-            }
-
-            var hintValue = SDL3.SDL_GetHint(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD);
-            Logger.Log($"Low latency keyboard hint value: {hintValue}", LoggingTarget.Runtime, LogLevel.Verbose);
-
-            if (hintValue != "1")
-                Logger.Log($"Failed to set low latency keyboard hint, current value {hintValue}, error: {SDL3.SDL_GetError()}", LoggingTarget.Runtime, LogLevel.Error);
-        });
+        if (hintValue != "1")
+            Logger.Log($"Failed to set low latency keyboard hint, current value {hintValue}, error: {SDL3.SDL_GetError()}", LoggingTarget.Runtime, LogLevel.Error);
     }
 }

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -40,6 +40,10 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
 
             SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
 
+            // This makes Win-key blocker work when raw input is enabled.
+            // after all low latency isn't meaningful for hotkeys
+            SDL3.SDL_SetHintWithPriority(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD_EXCLUDE_HOTKEYS, "1"u8, SDL_HintPriority.SDL_HINT_OVERRIDE);
+
             var hintValue = SDL3.SDL_GetHint(SDL3.SDL_HINT_WINDOWS_RAW_KEYBOARD);
             Logger.Log($"Low latency keyboard hint value: {hintValue}", LoggingTarget.Runtime, LogLevel.Verbose);
 

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -18,9 +18,6 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
 {
     public override void OnLoad(OsuGameBase gameBase, Scheduler scheduler)
     {
-        if (gameBase is not OsuGame game)
-            return;
-
         if (!OperatingSystem.IsWindows())
         {
             Logger.Log("Low latency keyboard patch is only supported on Windows, skipping.");

--- a/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
+++ b/osu.Plugin.Patches/LowLatencyKeyboardPlugin.cs
@@ -52,6 +52,4 @@ public partial class LowLatencyKeyboardPlugin : OsuPlugin
                 Logger.Log($"Failed to set low latency keyboard hint, current value {hintValue}, error: {SDL3.SDL_GetError()}", LoggingTarget.Runtime, LogLevel.Error);
         });
     }
-
-    private static readonly Type SDL3Window_Type = typeof(GameHost).Assembly.GetType("osu.Framework.Platform.SDL3.SDL3Window")!;
 }


### PR DESCRIPTION
Introduce a plugin that enables the Windows Raw Keyboard hint in SDL3 to reduce input latency for keyboards on Windows. This implementation checks for the operating system and SDL version before applying the hint.