### PR TITLE
Add Ranked Play Spectator plugin and screens

### DIFF
--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
@@ -1,0 +1,305 @@
+using osu.Framework.Allocation;
+using osu.Framework.Extensions;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osu.Framework.Screens;
+using osu.Framework.Threading;
+using osu.Game.Audio;
+using osu.Game.Beatmaps;
+using osu.Game.Beatmaps.Drawables.Cards;
+using osu.Game.Configuration;
+using osu.Game.Database;
+using osu.Game.Graphics;
+using osu.Game.Graphics.Sprites;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Localisation;
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Rooms;
+using osu.Game.Online.Spectator;
+using osu.Game.Overlays;
+using osu.Game.Overlays.Settings;
+using osu.Game.Screens.OnlinePlay.Match.Components;
+using osu.Game.Screens.Spectate;
+using osu.Game.Users;
+using osuTK;
+
+namespace osu.Plugin.Patches.RankedPlaySpectator;
+
+/// <summary>
+/// This screen serves as a temporary loading screen while we fetch the necessary data to start spectating a ranked play match,
+/// such as ensuring beatmap availability and preparing the spectator screen. Once the data is ready, it transitions to the <see cref="RankedPlaySpectatorScreen"/> to start spectating the match.
+/// </summary>
+public partial class RankedPlaySpectatorLoader : SpectatorScreen, IPreviewTrackOwner
+{
+    private readonly Room room;
+    private readonly APIUser[] users;
+
+    [Resolved]
+    private BeatmapLookupCache beatmapLookupCache { get; set; } = null!;
+
+    [Resolved]
+    private PreviewTrackManager previewTrackManager { get; set; } = null!;
+
+    [Resolved]
+    private BeatmapManager beatmaps { get; set; } = null!;
+
+    [Resolved]
+    private BeatmapModelDownloader beatmapDownloader { get; set; } = null!;
+
+    [Cached]
+    private OverlayColourProvider colourProvider = new OverlayColourProvider(OverlayColourScheme.Purple);
+
+    private Container beatmapPanelContainer = null!;
+    private RoundedButton watchButton = null!;
+    private SettingsCheckbox automaticDownload = null!;
+
+    private readonly Dictionary<int, SpectatorState> userStates = new();
+    private readonly Dictionary<int, SpectatorGameplayState> userGameplayStates = new();
+
+    private ScheduledDelegate? beatmapFetchCallback;
+    private APIBeatmapSet? beatmapSet;
+
+    public RankedPlaySpectatorLoader(Room room, APIUser[] users)
+        : base(users.Select(u => u.Id).ToArray())
+    {
+        this.room = room;
+        this.users = users;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load(OsuConfigManager config)
+    {
+        InternalChild = new Container
+        {
+            Masking = true,
+            CornerRadius = 20,
+            AutoSizeAxes = Axes.Both,
+            AutoSizeDuration = 500,
+            AutoSizeEasing = Easing.OutQuint,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre,
+            Children = new Drawable[]
+            {
+                new Box
+                {
+                    Colour = colourProvider.Background5,
+                    RelativeSizeAxes = Axes.Both,
+                },
+                new FillFlowContainer
+                {
+                    Margin = new MarginPadding(20),
+                    AutoSizeAxes = Axes.Both,
+                    Direction = FillDirection.Vertical,
+                    Anchor = Anchor.Centre,
+                    Origin = Anchor.Centre,
+                    Spacing = new Vector2(15),
+                    Children = new Drawable[]
+                    {
+                        new OsuSpriteText
+                        {
+                            Text = "Multiplayer Spectator Mode",
+                            Font = OsuFont.Default.With(size: 30),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        new FillFlowContainer
+                        {
+                            AutoSizeAxes = Axes.Both,
+                            Direction = FillDirection.Horizontal,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Spacing = new Vector2(15),
+                            Children = new Drawable[]
+                            {
+                                new FillFlowContainer
+                                {
+                                    AutoSizeAxes = Axes.Y,
+                                    Width = 290,
+                                    Direction = FillDirection.Vertical,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                    Spacing = new Vector2(5),
+                                    ChildrenEnumerable = users.Select(u => new UserGridPanel(u)
+                                    {
+                                        Height = 145,
+                                        RelativeSizeAxes = Axes.X,
+
+                                        // Hack to ensure the UserGridPanel is loaded
+                                        Anchor = Anchor.CentreLeft,
+                                        Origin = Anchor.CentreLeft,
+                                    })
+                                },
+                                new SpriteIcon
+                                {
+                                    Size = new Vector2(40),
+                                    Icon = FontAwesome.Solid.ArrowRight,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                },
+                                beatmapPanelContainer = new Container
+                                {
+                                    AutoSizeAxes = Axes.Both,
+                                    Anchor = Anchor.CentreLeft,
+                                    Origin = Anchor.CentreLeft,
+                                },
+                            }
+                        },
+                        automaticDownload = new SettingsCheckbox
+                        {
+                            LabelText = OnlineSettingsStrings.AutomaticallyDownloadMissingBeatmaps,
+                            Current = config.GetBindable<bool>(OsuSetting.AutomaticallyDownloadMissingBeatmaps),
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
+                        watchButton = new PurpleRoundedButton
+                        {
+                            Text = "Start Watching",
+                            Width = 250,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                            Action = scheduleStart,
+                            Enabled = { Value = false }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+        automaticDownload.Current.BindValueChanged(_ => checkForAutomaticDownload());
+    }
+
+    protected override void OnNewPlayingUserState(int userId, SpectatorState spectatorState) => Schedule(() =>
+    {
+        userStates[userId] = spectatorState;
+        checkStates();
+    });
+
+    protected override void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState) => Schedule(() =>
+    {
+        userGameplayStates[userId] = spectatorGameplayState;
+        checkStates();
+    });
+
+    protected override void FailGameplay(int userId)
+    {
+    }
+
+    protected override void QuitGameplay(int userId)
+    {
+    }
+
+    private void checkStates()
+    {
+        if (users.Length == 0) return;
+
+        // Ensure we have a state for all users, otherwise they haven't sent state yet
+        if (!users.All(u => userStates.ContainsKey(u.Id)))
+            return;
+
+        int? beatmapId = userStates.Values.First().BeatmapID;
+        bool allSameBeatmap = userStates.Values.All(s => s.BeatmapID == beatmapId);
+
+        if (allSameBeatmap && beatmapId != null)
+        {
+            showBeatmapPanel(beatmapId.Value);
+
+            bool allGameplayReady = users.All(u => userGameplayStates.ContainsKey(u.Id));
+            if (allGameplayReady)
+            {
+                var firstGameplayState = userGameplayStates.Values.First();
+                Beatmap.Value = firstGameplayState.Beatmap;
+                Ruleset.Value = firstGameplayState.Ruleset.RulesetInfo;
+                watchButton.Enabled.Value = true;
+            }
+            else
+            {
+                watchButton.Enabled.Value = false;
+            }
+        }
+        else
+        {
+            clearDisplay();
+        }
+    }
+
+    private void clearDisplay()
+    {
+        watchButton.Enabled.Value = false;
+        beatmapFetchCallback?.Cancel();
+        beatmapPanelContainer.Clear();
+        previewTrackManager.StopAnyPlaying(this);
+    }
+
+    private ScheduledDelegate? scheduledStart;
+
+    private void scheduleStart()
+    {
+        scheduledStart?.Cancel();
+        scheduledStart = Schedule(() =>
+        {
+            if (this.IsCurrentScreen())
+                start();
+            else
+                scheduleStart();
+        });
+
+        void start()
+        {
+            var firstGameplayState = userGameplayStates.Values.First();
+            Beatmap.Value = firstGameplayState.Beatmap;
+            Ruleset.Value = firstGameplayState.Ruleset.RulesetInfo;
+
+            this.Push(new RankedPlaySpectatorScreen(room, users));
+        }
+    }
+
+    private void showBeatmapPanel(int beatmapId)
+    {
+        if (beatmapPanelContainer.Children.Count > 0)
+            return;
+
+        beatmapLookupCache.GetBeatmapAsync(beatmapId).ContinueWith(t => beatmapFetchCallback = Schedule(() =>
+        {
+            var beatmap = t.GetResultSafely();
+
+            if (beatmap?.BeatmapSet == null)
+                return;
+
+            beatmapSet = beatmap.BeatmapSet;
+            beatmapPanelContainer.Child = new BeatmapCardNormal(beatmapSet, allowExpansion: false);
+            checkForAutomaticDownload();
+        }));
+    }
+
+    private void checkForAutomaticDownload()
+    {
+        if (beatmapSet == null)
+            return;
+
+        if (!automaticDownload.Current.Value)
+            return;
+
+        if (beatmaps.IsAvailableLocally(new BeatmapSetInfo { OnlineID = beatmapSet.OnlineID }))
+            return;
+
+        beatmapDownloader.Download(beatmapSet);
+    }
+
+    public override bool OnExiting(ScreenExitEvent e)
+    {
+        previewTrackManager.StopAnyPlaying(this);
+        return base.OnExiting(e);
+    }
+
+    public override void OnSuspending(ScreenTransitionEvent e)
+    {
+        previewTrackManager.StopAnyPlaying(this);
+        base.OnSuspending(e);
+    }
+}

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
@@ -1,4 +1,5 @@
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Extensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -60,6 +61,8 @@ public partial class RankedPlaySpectatorLoader : SpectatorScreen, IPreviewTrackO
 
     private ScheduledDelegate? beatmapFetchCallback;
     private APIBeatmapSet? beatmapSet;
+
+    private readonly Bindable<bool> automaticStart = new Bindable<bool>(true);
 
     public RankedPlaySpectatorLoader(Room room, APIUser[] users)
         : base(users.Select(u => u.Id).ToArray())
@@ -153,6 +156,13 @@ public partial class RankedPlaySpectatorLoader : SpectatorScreen, IPreviewTrackO
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,
                         },
+                        new SettingsCheckbox
+                        {
+                            LabelText = "Automatically start spectating when ready",
+                            Current = automaticStart,
+                            Anchor = Anchor.Centre,
+                            Origin = Anchor.Centre,
+                        },
                         watchButton = new PurpleRoundedButton
                         {
                             Text = "Start Watching",
@@ -216,6 +226,9 @@ public partial class RankedPlaySpectatorLoader : SpectatorScreen, IPreviewTrackO
                 Beatmap.Value = firstGameplayState.Beatmap;
                 Ruleset.Value = firstGameplayState.Ruleset.RulesetInfo;
                 watchButton.Enabled.Value = true;
+
+                if (automaticStart.Value)
+                    scheduleStart();
             }
             else
             {

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorLoader.cs
@@ -99,7 +99,7 @@ public partial class RankedPlaySpectatorLoader : SpectatorScreen, IPreviewTrackO
                     {
                         new OsuSpriteText
                         {
-                            Text = "Multiplayer Spectator Mode",
+                            Text = "Ranked Play Spectator Mode",
                             Font = OsuFont.Default.With(size: 30),
                             Anchor = Anchor.Centre,
                             Origin = Anchor.Centre,

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
@@ -17,7 +17,7 @@ namespace osu.Plugin.Patches.RankedPlaySpectator;
 
 public partial class RankedPlaySpectatorPlugin : OsuPlugin
 {
-    private readonly Bindable<string> roomId = new Bindable<string>();
+    private readonly Bindable<string> roomId = new Bindable<string>(string.Empty);
 
     public override IEnumerable<Drawable>? CreateSettingsControls() => new Drawable[]
     {

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
@@ -1,0 +1,88 @@
+using osu.Framework.Allocation;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Logging;
+using osu.Framework.Screens;
+using osu.Framework.Threading;
+using osu.Game;
+using osu.Game.Graphics.UserInterfaceV2;
+using osu.Game.Online.API;
+using osu.Game.Online.Rooms;
+using osu.Game.Overlays.Settings;
+using osu.Game.Plugins;
+using osu.Game.Screens;
+
+namespace osu.Plugin.Patches.RankedPlaySpectator;
+
+public partial class RankedPlaySpectatorPlugin : OsuPlugin
+{
+    private readonly Bindable<string> roomId = new Bindable<string>();
+
+    public override IEnumerable<Drawable>? CreateSettingsControls() => new Drawable[]
+    {
+        new SettingsItemV2(new FormNumberBox
+        {
+            Caption = "Room ID",
+            Current = roomId,
+        }),
+        new SettingsButtonV2
+        {
+            Text = "Start Spectating",
+            Action = startSpectating,
+        },
+    };
+
+    private void startSpectating()
+    {
+        if (!long.TryParse(roomId.Value, out var parsedRoomId))
+        {
+            Logger.Log($"Invalid Room ID: {roomId.Value}", level: LogLevel.Error);
+            return;
+        }
+
+        if (parsedRoomId <= 0)
+        {
+            Logger.Log($"Room ID must be a positive integer. Provided: {parsedRoomId}", level: LogLevel.Error);
+            return;
+        }
+
+        var getRoomReq = new GetRoomRequest(parsedRoomId);
+
+        getRoomReq.Failure += e =>
+        {
+            Logger.Log($"Failed to retrieve room details for Room ID {parsedRoomId}: {e}", level: LogLevel.Error);
+        };
+
+        getRoomReq.Success += r =>
+        {
+            scheduler.Add(() =>
+            {
+                var spectatorScreen = new RankedPlaySpectatorLoader(r, r.RecentParticipants.ToArray());
+
+                screenPerformer.PerformFromScreen(s => s.Push(spectatorScreen));
+            });
+        };
+
+        api.Queue(getRoomReq);
+    }
+
+    private IAPIProvider api { get; set; } = null!;
+    private IPerformFromScreenRunner screenPerformer { get; set; } = null!;
+    private Scheduler scheduler { get; set; } = null!;
+
+    public override void OnLoad(OsuGameBase gameBase, Scheduler scheduler)
+    {
+        if (gameBase is not OsuGame game)
+            return;
+
+        this.scheduler = scheduler;
+
+        game.InvokeWhenReady(d =>
+        {
+            var osuGame = (OsuGame)d;
+
+            api = osuGame.Dependencies.Get<IAPIProvider>();
+            screenPerformer = osuGame.Dependencies.Get<IPerformFromScreenRunner>();
+        });
+    }
+}

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
@@ -11,6 +11,7 @@ using osu.Game.Online.Rooms;
 using osu.Game.Overlays.Settings;
 using osu.Game.Plugins;
 using osu.Game.Screens;
+using MatchType = osu.Game.Online.Rooms.MatchType;
 
 namespace osu.Plugin.Patches.RankedPlaySpectator;
 
@@ -55,6 +56,12 @@ public partial class RankedPlaySpectatorPlugin : OsuPlugin
 
         getRoomReq.Success += r =>
         {
+            if (r.Type is not MatchType.RankedPlay and not MatchType.Matchmaking)
+            {
+                Logger.Log($"Room ID {parsedRoomId} is not a Ranked Play or Matchmaking room. Type: {r.Type}", level: LogLevel.Error);
+                return;
+            }
+
             scheduler.Add(() =>
             {
                 var spectatorScreen = new RankedPlaySpectatorLoader(r, r.RecentParticipants.ToArray());

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorPlugin.cs
@@ -24,6 +24,7 @@ public partial class RankedPlaySpectatorPlugin : OsuPlugin
         new SettingsItemV2(new FormNumberBox
         {
             Caption = "Room ID",
+            HintText = "Enter the Room ID of the Ranked Play room you want to spectate, you can find the ongoing rooms in the ranked play section of a user's profile page.",
             Current = roomId,
         }),
         new SettingsButtonV2

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
@@ -1,0 +1,14 @@
+using osu.Game.Online.API.Requests.Responses;
+using osu.Game.Online.Multiplayer;
+using osu.Game.Online.Rooms;
+using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
+
+namespace osu.Plugin.Patches.RankedPlaySpectator;
+
+public partial class RankedPlaySpectatorScreen : MultiSpectatorScreen
+{
+    public RankedPlaySpectatorScreen(Room room, APIUser[] users)
+        : base(room, users.Select(u => new MultiplayerRoomUser(u.Id) { User = u }).ToArray())
+    {
+    }
+}

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
@@ -1,14 +1,287 @@
+using osu.Framework.Allocation;
+using osu.Framework.Audio;
+using osu.Framework.Bindables;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Logging;
+using osu.Game.Configuration;
+using osu.Game.Graphics;
 using osu.Game.Online.API.Requests.Responses;
 using osu.Game.Online.Multiplayer;
 using osu.Game.Online.Rooms;
+using osu.Game.Online.Spectator;
 using osu.Game.Screens.OnlinePlay.Multiplayer.Spectate;
+using osu.Game.Screens.Play;
+using osu.Game.Screens.Play.HUD;
+using osu.Game.Screens.Play.Leaderboards;
+using osu.Game.Screens.Spectate;
+using osu.Game.Users;
+using osuTK;
 
 namespace osu.Plugin.Patches.RankedPlaySpectator;
 
-public partial class RankedPlaySpectatorScreen : MultiSpectatorScreen
+public partial class RankedPlaySpectatorScreen : SpectatorScreen
 {
     public RankedPlaySpectatorScreen(Room room, APIUser[] users)
-        : base(room, users.Select(u => new MultiplayerRoomUser(u.Id) { User = u }).ToArray())
+        : base(users.Select(static u => u.Id).ToArray())
     {
+        this.room = room;
+
+        instances = new PlayerArea[Users.Count];
+        leaderboardProvider = new MultiSpectatorLeaderboardProvider(users.Select(u => new MultiplayerRoomUser(u.Id) { User = u }).ToArray());
+    }
+
+    // Isolates beatmap/ruleset to this screen.
+    public override bool DisallowExternalBeatmapRulesetChanges => true;
+
+    // We are managing our own adjustments. For now, this happens inside the Player instances themselves.
+    public override bool? ApplyModTrackAdjustments => false;
+
+    public override bool HideOverlaysOnEnter => true;
+
+    /// <summary>
+    /// Whether all spectating players have finished loading.
+    /// </summary>
+    public bool AllPlayersLoaded => instances.All(p => p.PlayerLoaded);
+
+    internal DrawableGameplayLeaderboard Leaderboard { get; private set; } = null!;
+
+    protected override UserActivity InitialActivity => new UserActivity.SpectatingMultiplayerGame(Beatmap.Value.BeatmapInfo, Ruleset.Value);
+
+    [Resolved]
+    private OsuColour colours { get; set; } = null!;
+
+    [Resolved]
+    private MultiplayerClient multiplayerClient { get; set; } = null!;
+
+    [Cached(typeof(IGameplayLeaderboardProvider))]
+    private MultiSpectatorLeaderboardProvider leaderboardProvider { get; set; }
+
+    private IAggregateAudioAdjustment? boundAdjustments;
+
+    private readonly PlayerArea[] instances;
+    private MasterGameplayClockContainer masterClockContainer = null!;
+    private SpectatorSyncManager syncManager = null!;
+    private PlayerGrid grid = null!;
+    private PlayerArea? currentAudioSource;
+
+    private readonly Room room;
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        FillFlowContainer leaderboardFlow;
+        Container scoreDisplayContainer;
+
+        InternalChildren = new Drawable[]
+        {
+            masterClockContainer = new MasterGameplayClockContainer(Beatmap.Value, 0)
+            {
+                Child = new GridContainer
+                {
+                    RelativeSizeAxes = Axes.Both,
+                    RowDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                    Content = new[]
+                    {
+                        new Drawable[]
+                        {
+                            scoreDisplayContainer = new Container
+                            {
+                                RelativeSizeAxes = Axes.X,
+                                AutoSizeAxes = Axes.Y
+                            },
+                        },
+                        new Drawable[]
+                        {
+                            new GridContainer
+                            {
+                                RelativeSizeAxes = Axes.Both,
+                                ColumnDimensions = new[] { new Dimension(GridSizeMode.AutoSize) },
+                                Content = new[]
+                                {
+                                    new Drawable[]
+                                    {
+                                        leaderboardFlow = new FillFlowContainer
+                                        {
+                                            Anchor = Anchor.CentreLeft,
+                                            Origin = Anchor.CentreLeft,
+                                            AutoSizeAxes = Axes.Both,
+                                            Direction = FillDirection.Vertical,
+                                            Spacing = new Vector2(5)
+                                        },
+                                        grid = new PlayerGrid { RelativeSizeAxes = Axes.Both }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            syncManager = new SpectatorSyncManager(masterClockContainer)
+            {
+                ReadyToStart = performInitialSeek,
+            },
+        };
+
+        for (int i = 0; i < Users.Count; i++)
+            grid.Add(instances[i] = new PlayerArea(Users[i], syncManager.CreateManagedClock()));
+
+        LoadComponentAsync(leaderboardProvider, _ =>
+        {
+            AddInternal(leaderboardProvider);
+            foreach (var instance in instances)
+                leaderboardProvider.AddClock(instance.UserId, instance.SpectatorPlayerClock);
+
+            if (leaderboardProvider.TeamScores.Count == 2)
+            {
+                LoadComponentAsync(new MatchScoreDisplay
+                {
+                    Team1Score = { BindTarget = leaderboardProvider.TeamScores.First().Value },
+                    Team2Score = { BindTarget = leaderboardProvider.TeamScores.Last().Value },
+                }, scoreDisplayContainer.Add);
+            }
+        });
+        leaderboardFlow.Insert(0, Leaderboard = new DrawableGameplayLeaderboard
+        {
+            CollapseDuringGameplay = { Value = false },
+            AlwaysShown = true,
+        });
+    }
+
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        masterClockContainer.Reset();
+
+        // Start with adjustments from the first player to keep a sane state.
+        bindAudioAdjustments(instances.First());
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+
+        checkAudioSource();
+    }
+
+    private void checkAudioSource()
+    {
+        // always use the maximised player instance as the current audio source if there is one
+        if (grid.MaximisedCell?.Content is PlayerArea maximisedPlayer && maximisedPlayer == currentAudioSource)
+            return;
+
+        // if there is no maximised player instance and the previous audio source is still good to use, keep using it
+        if (grid.MaximisedCell == null && isCandidateAudioSource(currentAudioSource?.SpectatorPlayerClock))
+            return;
+
+        // at this point we're in one of the following scenarios:
+        // - the maximised player instance is not the current audio source => we want to switch to the maximised player instance
+        // - there is no maximised player instance, and the previous audio source is stopped => find another running audio source
+        currentAudioSource = grid.MaximisedCell?.Content as PlayerArea
+                             ?? instances.Where(i => isCandidateAudioSource(i.SpectatorPlayerClock)).MinBy(i => Math.Abs(i.SpectatorPlayerClock.CurrentTime - syncManager.CurrentMasterTime));
+
+        // Only bind adjustments if there's actually a valid source, else just use the previous ones to ensure no sudden changes to audio.
+        if (currentAudioSource != null)
+            bindAudioAdjustments(currentAudioSource);
+
+        foreach (var instance in instances)
+            instance.Mute = instance != currentAudioSource;
+    }
+
+    private void bindAudioAdjustments(PlayerArea first)
+    {
+        if (boundAdjustments != null)
+            masterClockContainer.AdjustmentsFromMods.UnbindAdjustments(boundAdjustments);
+
+        boundAdjustments = first.ClockAdjustmentsFromMods;
+        masterClockContainer.AdjustmentsFromMods.BindAdjustments(boundAdjustments);
+    }
+
+    private bool isCandidateAudioSource(SpectatorPlayerClock? clock)
+        => clock?.IsRunning == true && !clock.IsCatchingUp && !clock.WaitingOnFrames;
+
+    private void performInitialSeek()
+    {
+        // We want to start showing gameplay as soon as possible.
+        // Each client may be in a different place in the beatmap, so we need to do our best to find a common
+        // starting point.
+        //
+        // Preferring a lower value ensures that we don't have some clients stuttering to keep up.
+        List<double> minFrameTimes = new List<double>();
+
+        foreach (var instance in instances)
+        {
+            if (instance.Score == null)
+                continue;
+
+            minFrameTimes.Add(instance.Score.Replay.Frames.MinBy(f => f.Time)?.Time ?? 0);
+        }
+
+        // Remove any outliers (only need to worry about removing those lower than the mean since we will take a Min() after).
+        double mean = minFrameTimes.Average();
+        minFrameTimes.RemoveAll(t => mean - t > 1000);
+
+        double startTime = minFrameTimes.Min();
+
+        masterClockContainer.Reset(startTime, true);
+        Logger.Log($"Multiplayer spectator seeking to initial time of {startTime}");
+    }
+
+    protected override void OnNewPlayingUserState(int userId, SpectatorState spectatorState)
+    {
+    }
+
+    protected override void StartGameplay(int userId, SpectatorGameplayState spectatorGameplayState) => Schedule(() =>
+    {
+        var playerArea = instances.Single(i => i.UserId == userId);
+
+        // The multiplayer spectator flow requires the client to return to a higher level screen
+        // (ie. StartGameplay should only be called once per player).
+        //
+        // Meanwhile, the solo spectator flow supports multiple `StartGameplay` calls.
+        // To ensure we don't crash out in an edge case where this is called more than once in multiplayer,
+        // guard against re-entry for the same player.
+        if (playerArea.Score != null)
+            return;
+
+        playerArea.LoadScore(spectatorGameplayState.Score);
+    });
+
+    protected override void FailGameplay(int userId) => Schedule(() =>
+    {
+        // We probably want to visualise this in the future.
+
+        var instance = instances.Single(i => i.UserId == userId);
+        syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
+    });
+
+    protected override void PassGameplay(int userId) => Schedule(() =>
+    {
+        var instance = instances.Single(i => i.UserId == userId);
+        syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
+    });
+
+    protected override void QuitGameplay(int userId) => Schedule(() =>
+    {
+        RemoveUser(userId);
+
+        var instance = instances.Single(i => i.UserId == userId);
+
+        instance.FadeColour(colours.Gray4, 400, Easing.OutQuint);
+        syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
+    });
+
+    public override bool OnBackButton()
+    {
+        if (multiplayerClient.Room == null)
+            return base.OnBackButton();
+
+        // On a manual exit, set the player back to idle unless gameplay has finished.
+        // Of note, this doesn't cover exiting using alt-f4 or menu home option.
+        if (multiplayerClient.Room.State != MultiplayerRoomState.Open)
+            multiplayerClient.ChangeState(MultiplayerUserState.Idle).FireAndForget();
+
+        return base.OnBackButton();
     }
 }

--- a/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
+++ b/osu.Plugin.Patches/RankedPlaySpectator/RankedPlaySpectatorScreen.cs
@@ -51,9 +51,6 @@ public partial class RankedPlaySpectatorScreen : SpectatorScreen
     [Resolved]
     private OsuColour colours { get; set; } = null!;
 
-    [Resolved]
-    private MultiplayerClient multiplayerClient { get; set; } = null!;
-
     [Cached(typeof(IGameplayLeaderboardProvider))]
     private MultiSpectatorLeaderboardProvider leaderboardProvider { get; set; }
 
@@ -271,17 +268,4 @@ public partial class RankedPlaySpectatorScreen : SpectatorScreen
         instance.FadeColour(colours.Gray4, 400, Easing.OutQuint);
         syncManager.RemoveManagedClock(instance.SpectatorPlayerClock);
     });
-
-    public override bool OnBackButton()
-    {
-        if (multiplayerClient.Room == null)
-            return base.OnBackButton();
-
-        // On a manual exit, set the player back to idle unless gameplay has finished.
-        // Of note, this doesn't cover exiting using alt-f4 or menu home option.
-        if (multiplayerClient.Room.State != MultiplayerRoomState.Open)
-            multiplayerClient.ChangeState(MultiplayerUserState.Idle).FireAndForget();
-
-        return base.OnBackButton();
-    }
 }


### PR DESCRIPTION
Introduce a new plugin for spectating Ranked Play matches, including settings for room ID and functionality to start spectating.

TODO:
- [ ] Chat is unavailable due to a lack of access permission. We may want to remove the chat display.
- [ ] The spectator screen doesn't change to the next song automatically after a game ends.
... maybe more