### PR TITLE
Fix anchor positioning in LegacyHealthOverlay

### DIFF
--- a/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
+++ b/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
@@ -2,6 +2,8 @@ using osu.Framework.Graphics;
 using osu.Game.Skinning;
 using osu.Game.Beatmaps.Timing;
 using osu.Framework.Graphics.Containers;
+using osu.Framework.Extensions.EnumExtensions;
+using osuTK;
 
 namespace osu.Plugin.LegacyExperience.Gameplay;
 

--- a/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
+++ b/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
@@ -33,7 +33,7 @@ public partial class LegacyHealthOverlay : BreakTrackingContainer, ISerialisable
 
         // they are awared of the fact that health overlay usually takes up the full screen area
         // but they simply did a ugly hack to make it work
-        // see https://github.com/ppy/osu/blob/458a27c99a010310d75cce86ed5634250ff7bb15/osu.Game/Screens/Play/HUDOverlay.cs#L299
+        // see https://github.com/ppy/osu/blob/458a27c99a010310d75cce86ed5634250ff7bb15/osu.Game/Screens/Play/HUDOverlay.cs#L299-L303
         // use a custom and compute anchor position ourselves to avoid taking the full screen area
         // This fixes that chat display and other things being squeezed to the bottom of the screen when health overlay is enabled
         if (Anchor.HasFlagFast(Anchor.y0))

--- a/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
+++ b/osu.Plugin.LegacyExperience/Gameplay/LegacyHealthOverlay.cs
@@ -27,6 +27,24 @@ public partial class LegacyHealthOverlay : BreakTrackingContainer, ISerialisable
         };
     }
 
+    protected override void LoadComplete()
+    {
+        base.LoadComplete();
+
+        // they are awared of the fact that health overlay usually takes up the full screen area
+        // but they simply did a ugly hack to make it work
+        // see https://github.com/ppy/osu/blob/458a27c99a010310d75cce86ed5634250ff7bb15/osu.Game/Screens/Play/HUDOverlay.cs#L299
+        // use a custom and compute anchor position ourselves to avoid taking the full screen area
+        // This fixes that chat display and other things being squeezed to the bottom of the screen when health overlay is enabled
+        if (Anchor.HasFlagFast(Anchor.y0))
+        {
+            var relativeAnchorPosition = RelativeAnchorPosition;
+
+            Anchor = Anchor.Custom;
+            RelativeAnchorPosition = relativeAnchorPosition;
+        }
+    }
+
     protected override void ScheduleBreakAnimations(IReadOnlyList<BreakPeriod> breaks)
     {
         foreach (var period in breaks)


### PR DESCRIPTION
Adjust anchor positioning in the LegacyHealthOverlay to prevent UI distortion when the health overlay is enabled. This change ensures that the chat display and other UI elements are not squeezed to the bottom of the screen.