### PR TITLE
Improve plugin subsection display and order

### DIFF
--- a/osu.Game.Rulesets.PluginsLoader/PluginSubsection.cs
+++ b/osu.Game.Rulesets.PluginsLoader/PluginSubsection.cs
@@ -23,8 +23,10 @@ namespace osu.Game.Rulesets.PluginsLoader;
 
 public partial class PluginSubsection : SettingsSubsection
 {
-    protected override LocalisableString Header => Plugin.DisplayName ?? Plugin.GetType().Name;
+    protected override LocalisableString Header => DisplayName;
     protected readonly OsuPlugin Plugin;
+
+    public string DisplayName => GetReadablePluginName(Plugin);
 
     public readonly BindableBool Enabled = new BindableBool();
 
@@ -284,5 +286,20 @@ public partial class PluginSubsection : SettingsSubsection
             headerText.FadeColour(col, 300, Easing.OutQuint);
             descriptionText?.FadeColour(col, 300, Easing.OutQuint);
         }
+    }
+
+    private static string GetReadablePluginName(OsuPlugin plugin)
+    {
+        if (plugin.DisplayName != null)
+            return plugin.DisplayName;
+
+        var typeName = plugin.GetType().ReadableName();
+
+        const string suffix = "Plugin";
+
+        if (typeName.EndsWith(suffix, StringComparison.Ordinal))
+            return typeName.Substring(0, typeName.Length - suffix.Length);
+
+        return typeName;
     }
 }

--- a/osu.Game.Rulesets.PluginsLoader/PluginsSection.cs
+++ b/osu.Game.Rulesets.PluginsLoader/PluginsSection.cs
@@ -13,4 +13,17 @@ public partial class PluginsSection : SettingsSection
     {
         Icon = FontAwesome.Solid.PuzzlePiece,
     };
+
+    private readonly SortedList<string, PluginSubsection> pluginSubsections = new SortedList<string, PluginSubsection>(StringComparer.OrdinalIgnoreCase);
+
+    public void Add(PluginSubsection pluginSubsection)
+    {
+        pluginSubsections.Add(pluginSubsection.DisplayName, pluginSubsection);
+        FlowContent.Add(pluginSubsection);
+
+        int position = 0;
+
+        foreach (var (k, v) in pluginSubsections)
+            FlowContent.SetLayoutPosition(v, position++);
+    }
 }

--- a/osu.Game.Rulesets.PluginsLoader/PluginsSection.cs
+++ b/osu.Game.Rulesets.PluginsLoader/PluginsSection.cs
@@ -18,7 +18,10 @@ public partial class PluginsSection : SettingsSection
 
     public void Add(PluginSubsection pluginSubsection)
     {
-        pluginSubsections.Add(pluginSubsection.DisplayName, pluginSubsection);
+        // avoid plugins with the same name
+        var key = $"{pluginSubsection.DisplayName}, {pluginSubsection.GetType().AssemblyQualifiedName}";
+
+        pluginSubsections.Add(key, pluginSubsection);
         FlowContent.Add(pluginSubsection);
 
         int position = 0;


### PR DESCRIPTION
Enhance the display of plugin subsection headers and ensure a fixed display order for plugins in the settings section.