### PR TITLE
Fix FPS limiters application

### DIFF
--- a/osu.Plugin.Patches/CustomLimiterPlugin.cs
+++ b/osu.Plugin.Patches/CustomLimiterPlugin.cs
@@ -7,6 +7,8 @@ using osu.Framework.Extensions.IEnumerableExtensions;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Platform;
+using osu.Framework.Threading;
+using osu.Game;
 using osu.Game.Configuration;
 using osu.Game.Graphics.UserInterfaceV2;
 using osu.Game.Overlays;
@@ -39,7 +41,7 @@ public partial class CustomLimiterPlugin : OsuPlugin
 
     public override IEnumerable<Drawable>? CreateSettingsControls()
     {
-        return new CustomLimiterSettings
+        return new CustomLimiterSettings(this)
         {
             AutoSizeAxes = Axes.Y,
             RelativeSizeAxes = Axes.X,
@@ -52,12 +54,51 @@ public partial class CustomLimiterPlugin : OsuPlugin
         }.Yield();
     }
 
+    private GameHost host = null!;
+    private readonly Bindable<FrameSync> frameSync = new Bindable<FrameSync>();
+
+    public override void OnLoad(OsuGameBase gameBase, Scheduler scheduler)
+    {
+        if (gameBase is not OsuGame)
+            return;
+
+        gameBase.InvokeWhenReady(d =>
+        {
+            var dependencies = ((CompositeDrawable)d).Dependencies;
+
+            host = dependencies.Get<GameHost>();
+
+            dependencies.Get<FrameworkConfigManager>().BindWith(FrameworkSetting.FrameSync, frameSync);
+
+            // Ensure limiters are applied even if CustomLimiterSettings is not created.
+            // CreateSettingsControls are only called the first time the settings overlay is opened, so if the user never opens it, the limiters will not be applied without this.
+            ApplyLimiters();
+        });
+    }
+
+    private void ApplyLimiters()
+    {
+        if (frameSync.Value is not FrameSync.Unlimited || !Enabled.Value)
+        {
+            GameHostAccessor.ApplyHostDefaultLimiter(host);
+            return;
+        }
+
+        double applyValue(Bindable<double> original) => SyncThreadLimits.Value ? InputThreadLimit.Value : original.Value;
+
+        host.MaximumUpdateHz = applyValue(UpdateThreadLimit);
+        host.MaximumDrawHz = applyValue(DrawThreadLimit);
+        host.AudioThread.ActiveHz = applyValue(AudioThreadLimit);
+
+        // Must be done in the end, the host schedules a task to reset the limiter on the InputThread (known as MainThread) when mutating MaximumUpdateHz
+        host.InputThread.ActiveHz = InputThreadLimit.Value;
+    }
+
     private partial class CustomLimiterSettings : Container
     {
         public readonly Bindable<bool> Enabled = new Bindable<bool>();
 
-        [Resolved]
-        private GameHost host { get; set; } = null!;
+        private readonly CustomLimiterPlugin plugin;
 
         private FillFlowContainer otherThreadsContainer = null!;
 
@@ -78,6 +119,11 @@ public partial class CustomLimiterPlugin : OsuPlugin
             yield return DrawThreadLimit;
             yield return AudioThreadLimit;
             yield return InputThreadLimit;
+        }
+
+        public CustomLimiterSettings(CustomLimiterPlugin plugin)
+        {
+            this.plugin = plugin;
         }
 
         [BackgroundDependencyLoader]
@@ -140,7 +186,7 @@ public partial class CustomLimiterPlugin : OsuPlugin
             base.LoadComplete();
 
             foreach (var bindable in limiterBindables())
-                bindable.BindValueChanged(_ => applyLimiters());
+                bindable.BindValueChanged(_ => plugin.ApplyLimiters());
 
             SyncThreadLimits.BindValueChanged(_ => updateAll());
             frameSync.BindValueChanged(_ => updateAll());
@@ -150,7 +196,7 @@ public partial class CustomLimiterPlugin : OsuPlugin
             void updateAll()
             {
                 updateUI();
-                applyLimiters();
+                plugin.ApplyLimiters();
             }
         }
 
@@ -195,24 +241,6 @@ public partial class CustomLimiterPlugin : OsuPlugin
             {
                 note.Value = null;
             }
-        }
-
-        private void applyLimiters()
-        {
-            if (frameSync.Value is not FrameSync.Unlimited || !Enabled.Value)
-            {
-                GameHostAccessor.ApplyHostDefaultLimiter(host);
-                return;
-            }
-
-            double applyValue(Bindable<double> original) => SyncThreadLimits.Value ? InputThreadLimit.Value : original.Value;
-
-            host.MaximumUpdateHz = applyValue(UpdateThreadLimit);
-            host.MaximumDrawHz = applyValue(DrawThreadLimit);
-            host.AudioThread.ActiveHz = applyValue(AudioThreadLimit);
-
-            // Must be done in the end, the host schedules a task to reset the limiter on the InputThread (known as MainThread) when mutating MaximumUpdateHz
-            host.InputThread.ActiveHz = InputThreadLimit.Value;
         }
 
         private static SettingsItemV2 createLimiterSlider(string threadName, BindableDouble bindable)

--- a/osu.Plugin.Patches/CustomLimiterPlugin.cs
+++ b/osu.Plugin.Patches/CustomLimiterPlugin.cs
@@ -22,7 +22,7 @@ namespace osu.Plugin.Patches;
 /// This plugin adds custom FPS limiters for each thread, allowing players to set different FPS limits for input, audio, update and draw threads when frame sync is set to unlimited.
 /// It also has an option to sync all thread limiters with the input thread limiter for easier configuration.
 /// </summary>
-public partial class CustomLimiterPlugin : OsuPlugin
+public partial class CustomLimiterPlugin : OsuPlugin, IHasLimiterBindables
 {
     [SettingSource("Sync All Threads")]
     public BindableBool SyncThreadLimits { get; } = new BindableBool(false);
@@ -41,7 +41,7 @@ public partial class CustomLimiterPlugin : OsuPlugin
 
     public override IEnumerable<Drawable>? CreateSettingsControls()
     {
-        return new CustomLimiterSettings(this)
+        return new CustomLimiterSettings
         {
             AutoSizeAxes = Axes.Y,
             RelativeSizeAxes = Axes.X,
@@ -70,13 +70,17 @@ public partial class CustomLimiterPlugin : OsuPlugin
 
             dependencies.Get<FrameworkConfigManager>().BindWith(FrameworkSetting.FrameSync, frameSync);
 
+            foreach (var bindable in this.LimiterBindables())
+                bindable.BindValueChanged(_ => applyLimiters());
+
             // Ensure limiters are applied even if CustomLimiterSettings is not created.
             // CreateSettingsControls are only called the first time the settings overlay is opened, so if the user never opens it, the limiters will not be applied without this.
-            ApplyLimiters();
+            Enabled.BindValueChanged(_ => applyLimiters());
+            frameSync.BindValueChanged(_ => applyLimiters(), true);
         });
     }
 
-    private void ApplyLimiters()
+    private void applyLimiters()
     {
         if (frameSync.Value is not FrameSync.Unlimited || !Enabled.Value)
         {
@@ -94,37 +98,22 @@ public partial class CustomLimiterPlugin : OsuPlugin
         host.InputThread.ActiveHz = InputThreadLimit.Value;
     }
 
-    private partial class CustomLimiterSettings : Container
+    private partial class CustomLimiterSettings : Container, IHasLimiterBindables
     {
-        public readonly Bindable<bool> Enabled = new Bindable<bool>();
-
-        private readonly CustomLimiterPlugin plugin;
+        public Bindable<bool> Enabled { get; } = new Bindable<bool>();
 
         private FillFlowContainer otherThreadsContainer = null!;
 
-        public readonly BindableBool SyncThreadLimits = new BindableBool();
-        public readonly BindableDouble InputThreadLimit = createLimiterBindable();
-        public readonly BindableDouble AudioThreadLimit = createLimiterBindable();
-        public readonly BindableDouble UpdateThreadLimit = createLimiterBindable();
-        public readonly BindableDouble DrawThreadLimit = createLimiterBindable();
+        public BindableBool SyncThreadLimits { get; } = new BindableBool();
+        public BindableDouble InputThreadLimit { get; } = createLimiterBindable();
+        public BindableDouble AudioThreadLimit { get; } = createLimiterBindable();
+        public BindableDouble UpdateThreadLimit { get; } = createLimiterBindable();
+        public BindableDouble DrawThreadLimit { get; } = createLimiterBindable();
 
         private Bindable<FrameSync> frameSync = new Bindable<FrameSync>();
         private Bindable<ExecutionMode> executionMode = new Bindable<ExecutionMode>();
 
         private readonly Bindable<SettingsNote.Data?> note = new Bindable<SettingsNote.Data?>();
-
-        private IEnumerable<BindableDouble> limiterBindables()
-        {
-            yield return UpdateThreadLimit;
-            yield return DrawThreadLimit;
-            yield return AudioThreadLimit;
-            yield return InputThreadLimit;
-        }
-
-        public CustomLimiterSettings(CustomLimiterPlugin plugin)
-        {
-            this.plugin = plugin;
-        }
 
         [BackgroundDependencyLoader]
         private void load(FrameworkConfigManager frameworkConfig)
@@ -185,19 +174,10 @@ public partial class CustomLimiterPlugin : OsuPlugin
         {
             base.LoadComplete();
 
-            foreach (var bindable in limiterBindables())
-                bindable.BindValueChanged(_ => plugin.ApplyLimiters());
-
-            SyncThreadLimits.BindValueChanged(_ => updateAll());
-            frameSync.BindValueChanged(_ => updateAll());
-            executionMode.BindValueChanged(_ => updateAll());
-            Enabled.BindValueChanged(_ => updateAll(), true);
-
-            void updateAll()
-            {
-                updateUI();
-                plugin.ApplyLimiters();
-            }
+            SyncThreadLimits.BindValueChanged(_ => updateUI());
+            frameSync.BindValueChanged(_ => updateUI());
+            executionMode.BindValueChanged(_ => updateUI());
+            Enabled.BindValueChanged(_ => updateUI(), true);
         }
 
         private void updateUI()
@@ -216,7 +196,7 @@ public partial class CustomLimiterPlugin : OsuPlugin
 
             bool applyCustomLimiter = frameSync.Value is FrameSync.Unlimited;
 
-            foreach (var bindable in limiterBindables())
+            foreach (var bindable in this.LimiterBindables())
                 bindable.Disabled = !applyCustomLimiter;
 
             if (!applyCustomLimiter)
@@ -298,3 +278,23 @@ public partial class CustomLimiterPlugin : OsuPlugin
         };
     }
 }
+
+interface IHasLimiterBindables
+{
+    BindableDouble InputThreadLimit { get; }
+    BindableDouble AudioThreadLimit { get; }
+    BindableDouble UpdateThreadLimit { get; }
+    BindableDouble DrawThreadLimit { get; }
+}
+
+static class LimiterBindableExtensions
+{
+    public static IEnumerable<BindableDouble> LimiterBindables(this IHasLimiterBindables hasLimiters)
+    {
+        yield return hasLimiters.UpdateThreadLimit;
+        yield return hasLimiters.DrawThreadLimit;
+        yield return hasLimiters.AudioThreadLimit;
+        yield return hasLimiters.InputThreadLimit;
+    }
+}
+


### PR DESCRIPTION
resolves #89.

Ensure FPS limiters are applied even if the settings are never opened. This change modifies the plugin to apply limiters during the loading process, ensuring consistent behavior regardless of user interaction with the settings overlay. Also warns us that Drawables are not reliable unless presented in such scenarios, the plugin instance is where your logic should happen.